### PR TITLE
fix some issues with mocha tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,8 @@ module.exports = {
     "env": {
         "browser": true,
         "es6": true,
-        "node": true
+        "node": true,
+        "mocha": true
     },
     // "standard": {
     //     "env": ["mocha"]

--- a/test/integration/workflows.js
+++ b/test/integration/workflows.js
@@ -1,8 +1,7 @@
 'use strict';
 
-const fs = require('fs');
 const chai = require('chai');
-const assert = chai.assert;
+const {assert} = chai;
 const chaiHttp = require('chai-http');
 chai.use(chaiHttp);
 const U = require('../utils.js');

--- a/test/unit/atlasmakerServer.test.js
+++ b/test/unit/atlasmakerServer.test.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 var assert = require("assert");
 const AMS = require('../../controller/atlasmakerServer/atlasmakerServer.js');
 const datadir = './test/data/';
@@ -52,7 +53,7 @@ describe('UNIT TESTING ATLASMAKER SERVER', function () {
   });
 
   describe('Painting', function () {
-    it('Convert screen coordinates to volume index', async function () {
+    it('Convert screen coordinates to volume index', function () {
       const s = [10, 20, 30];
       const mri = {
         s2v: { X:99, dx:-1, x:0, Y:0, dy:1, y:2, Z:299, dz:-1, z:1},
@@ -85,10 +86,10 @@ describe('UNIT TESTING ATLASMAKER SERVER', function () {
     it('Find similar project names', async function () {
       const data = {
         type: "similarProjectNamesQuery",
-        metadata: {projectName: U.projectTest.shortname.slice(0,3)}
+        metadata: {projectName: U.projectTest.shortname.slice(0, 3)}
       };
       const result = await AMS.querySimilarProjectNames(data);
-      assert.equal(result[0].name, U.projectTest.name);
+      assert.ok(result.filter((e) => e.name === U.projectTest.name).length);
     });
   });
 
@@ -105,6 +106,7 @@ describe('UNIT TESTING ATLASMAKER SERVER', function () {
       const jpg = await AMS.drawSlice(mri, view, slice);
       const newPath = "./test/images/slice-bert-cor-50.jpg";
       const refPath = "./test/data/reference-images/slice-bert-cor-50.jpg";
+      await fs.promises.mkdir(path.dirname(newPath), { recursive: true });
       fs.writeFileSync(newPath, jpg.data);
       const diff = U.compareImages(newPath, refPath);
       assert(diff<10);

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,29 +1,31 @@
 var fs = require('fs');
+const path = require('path');
 const monk = require('monk');
 const db = monk('localhost:27017/brainbox');
 const rimraf = require("rimraf");
 const {PNG} = require('pngjs');
 var jpeg = require('jpeg-js');
 const pixelmatch = require('pixelmatch');
+const { exec } = require("child_process");
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
-const localBertURL = "http://127.0.0.1:3001/test_data/bert_brain.nii.gz";
+const serverURL = "http://127.0.0.1:3001";
+const localBertURL = serverURL + "/test_data/bert_brain.nii.gz";
 const cheetahURL = "https://zenodo.org/record/44846/files/MRI.nii.gz?download=1";
-const serverURL = "http://localhost:3001";
 const testToken = "qwertyuiopasdfghjklzxcvbnm";
 const testTokenDuration = 2 * (1000 * 3600); // 2h
 const noTimeout = 0; // disable timeout
-const longTimeout = 10 * 1000; // 30 sec
-const mediumTimeout = 5 * 1000; // 10 sec
-const shortTimeout = 3 * 1000; // 5 sec
+const longTimeout = 10 * 1000; // 10 sec
+const mediumTimeout = 5 * 1000; // 5 sec
+const shortTimeout = 3 * 1000; // 3 sec
 
 const userFoo = {
   name: "Founibald Barr",
   nickname: "foo",
   url: "https://foo.bar",
   brainboxURL: "/user/foo",
-  avatarURL: "http://127.0.0.1:3001/test_data/foo.png",
+  avatarURL: serverURL + "/test_data/foo.png",
   joined: (new Date()).toJSON()
 };
 const userBar = {
@@ -31,7 +33,7 @@ const userBar = {
   nickname: "bar",
   url: "https://bar.foo",
   brainboxURL: "/user/foo",
-  avatarURL: "http://127.0.0.1:3001/test_data/bar.png",
+  avatarURL: serverURL + "/test_data/bar.png",
   joined: (new Date()).toJSON()
 };
 const userFooB = {
@@ -39,7 +41,7 @@ const userFooB = {
   username: "foo",
   url: "https://foo.bar",
   brainboxURL: "/user/foo",
-  avatarURL: "http://127.0.0.1:3001/test_data/foo.png",
+  avatarURL: serverURL + "/test_data/foo.png",
   joined: (new Date()).toJSON()
 };
 const userBarB = {
@@ -47,7 +49,7 @@ const userBarB = {
   username: "bar",
   url: "https://bar.foo",
   brainboxURL: "/user/foo",
-  avatarURL: "http://127.0.0.1:3001/test_data/bar.png",
+  avatarURL: serverURL + "/test_data/bar.png",
   joined: (new Date()).toJSON()
 };
 const projectTest = {
@@ -73,7 +75,7 @@ const projectTest = {
   },
   files: {
     list: [
-      "http://127.0.0.1:3001/test_data/bert_brain.nii.gz",
+      serverURL + "/test_data/bert_brain.nii.gz",
       "https://zenodo.org/record/44855/files/MRI-n4.nii.gz",
       "http://files.figshare.com/2284784/MRI_n4.nii.gz",
       "https://dl.dropbox.com/s/cny5b3so267bv94/p32-f18-uchar.nii.gz",
@@ -97,8 +99,7 @@ const projectTest = {
 
 function currentDirectory() {
   console.log("Current directory:", __dirname);
-  const { exec } = require("child_process");
-  exec('ls -l', (error, stdout, stderr) => {
+  exec('ls -l', (error, stdout) => {
     console.log(stdout);
   });
 }
@@ -197,7 +198,6 @@ async function waitUntilHTMLRendered(page, timeout = 30000) {
       // console.log("Page rendered fully..");
       break;
     }
-
     lastHTMLSize = currentHTMLSize;
     await page.waitFor(checkDurationMsecs);
   }
@@ -206,8 +206,9 @@ async function waitUntilHTMLRendered(page, timeout = 30000) {
 async function comparePageScreenshots(testPage, url, filename) {
   const newPath = './test/screenshots/' + filename;
   const refPath = './test/data/reference-screenshots/' + filename;
-  await testPage.goto(url, {waitUntil: 'networkidle0'});
-  await waitUntilHTMLRendered(testPage);
+  await testPage.goto(url, {waitUntil: 'networkidle0', timeout: 60000});
+  // await waitUntilHTMLRendered(testPage);
+  fs.mkdirSync(path.dirname(newPath), { recursive: true });
   await testPage.screenshot({path:'./test/screenshots/' + filename});
   const pixdiff = compareImages(newPath, refPath);
 


### PR DESCRIPTION
<!-- Thank you for your contribution to BrainBox -->

<!-- Give a short title and description for your pull request: -->
I had some trouble running mocha tests. These are some small fixes I had to do.

---
<!-- Run the tests. Replace each `[ ]` by `[X]` when the step is complete.-->
- [ X ] These changes fix #241 (github issue number if applicable).
- [ X ] ```npm run mocha-test``` ran with full success.
- [ ] ```npm run mocha-test``` ran resulted in  failure in _____

<!-- Replace `__` with appropriate information: -->
- [ ] I implemented tests for the changes I made OR
- [ X ] These changes do not require tests because no new features

<!-- Make sure that "Allow edits from maintainers" checkbox is checked.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification. -->


- [ ] All BrainBox tools behave as expected:
    * **KEYS**
        * right and left arrow keys
            - [ ] jump to next or previous slice within one brain, respectively
            - [ ] update the slider accordingly
            - [ ] update the slice number accordingly (upper left corner of the viewer window)
        * down and up arrow keys
            - [ ] jump to the next or previous brain within one project, respectively
            - [ ] update the selected subject in the annotation table
    * **TOOL BUTTONS**
        * minus
            - [ ] jumps to the previous slice within one brain
            - [ ] updates the slider accordingly
            - [ ] updates the slice number accordingly (upper left corner of the viewer window)
        * plus
            - [ ] jumps to the next slice within one brain
            - [ ] updates the slider accordingly
            - [ ] updates the slice number accordingly (upper left corner of the viewer window)
        * slider
            - [ ] updates slice view and slice number on the fly
        * sag / cor / axi buttons
            - [ ] switch view between the three orthogonal planes
        * show tool
            - [ ] when you click and drag in your browser window, this tool displays a cirlce at the position of your mouse click & drag as well as the user name in all browser windows connected to the same brain
        * the numbers at the bottom of the tool panel
            - [ ] change pencil size and eraser size accordingly
        * pencil tool
            - [ ] draws a line in the colour displayed in the color field
            - [ ] in combination with bucket tool filles a complete area with the chosen colour (be sure to have closed the contour line ;) Otherwise, the undo button will be your friend ;)
            - [ ] updates length and volume information (of what has been segmented) in the upper left corner of the viewer
        * erase tool
            - [ ] erases upon click drag from the annotation
            - [ ] in combination with the bucket tool erases the complete area of the color where you click
        * fill bucket tool
            * in combination with pencil tool
                - [ ] fills a complete area with the colour displayed in the colour field
            * in combination with erase tool
                - [ ] erases the complete area that is filled by the colour of where you click
        * colour field
            - [ ] displays the currently chosen colour to draw and fill
            - [ ] on click opens the set of colours available within the chosen label set where a new colour can be selected upon click
        * ruler tool
            - [ ] measures the distance between start and end of your defined path
                - [ ] points of mouse click appear and stay visible until you hit return key (this functionality is currently broken!) (you can click as many points as you wish to define the path you are interested in)
                - [ ] on return key, BrainBox will print the distance into the chat field (the ruler tool seems to be currently broken!!!)
        * adjust tool
            - [ ] slide opacity of overlaid annotation from 0 to 100%
            - [ ] increase or decrease brightness of the underlying MRI data
            - [ ] increase or decrease the contrast of the underlying MRI data
        * eyedropper tool
            - [ ] updates the colour field in the tool panel
            - [ ] displays/updates the region name in the upper left corner of the viewer
        * undo tool
            - [ ] undoes the user's actions in reverse chronological order and currently has the bug that it even undoes actions in slices you are currently not seeing! and there is currently no redo...
        * save button
            - [ ] saves the annotation of the data set into the data base
            - [ ] displays a message that user needs to login in case they are not
            - [ ] display a message `Atlas saved Wed Oct 18 2017 12:49:12 GMT+0200 (CEST)`


