### PR TITLE
allow the use of non-secure websockets

### DIFF
--- a/cfg.json.example
+++ b/cfg.json.example
@@ -1,7 +1,7 @@
 {
     "hostname": "http://localhost:3001",
     "wshostname": "localhost:8080",
-    "secure": true,
+    "secure": false,
     "ssl_key": "./key.pem",
     "ssl_cert": "./cert.pem",
     "ssl_chain": null

--- a/test/integration/workflow-ws.js
+++ b/test/integration/workflow-ws.js
@@ -1,11 +1,13 @@
 'use strict';
 
+const fs = require('fs');
 const chai = require('chai');
-const assert = chai.assert;
+const {assert} = chai;
 const chaiHttp = require('chai-http');
 chai.use(chaiHttp);
 const WebSocket = require('ws');
 const U = require('../utils.js');
+const Config = JSON.parse(fs.readFileSync('./cfg.json'));
 
 let u1, u2;
 const msgEcho = JSON.stringify({type:"echo", msg:"hi bruh"});
@@ -20,10 +22,17 @@ const msgSendAtlas = {
 };
 let mri;
 
+let wshost;
+if(Config.secure) {
+  wshost = "wss://localhost:8080";
+} else {
+  wshost = "ws://localhost:8080";
+}
+
 describe('TESTING WEBSOCKET WORKFLOW', function () {
   before( function () {
-    u1 = new WebSocket('wss://localhost:8080');
-    u2 = new WebSocket('wss://localhost:8080');
+    u1 = new WebSocket(wshost);
+    u2 = new WebSocket(wshost);
   });
 
   after( function () {

--- a/view/atlasmaker/src/atlasmaker-draw.js
+++ b/view/atlasmaker/src/atlasmaker-draw.js
@@ -14,8 +14,8 @@ export var AtlasMakerDraw = {
      */
   resizeWindow: function () {
     const me = AtlasMakerWidget;
-    const wH = me.container.height();
-    const wW = me.container.width();
+    const wH = me.container.clientHeight;
+    const wW = me.container.clientWidth;
     const wAspect = wW/wH;
     const bAspect = me.brainW*me.brainWdim/(me.brainH*me.brainHdim);
 
@@ -107,8 +107,8 @@ export var AtlasMakerDraw = {
    */
   displayInformation: function () {
     var me = AtlasMakerWidget;
-    var text = me.container.find("#text-layer");
-    var vector = me.container.find("#vector-layer");
+    var text = me.container.querySelector("#text-layer");
+    var vector = me.container.querySelector("#vector-layer");
     let txtStr;
     let svgStr;
 
@@ -120,14 +120,14 @@ export var AtlasMakerDraw = {
         txtStr += "<span>" + k + ": " + me.info[k] + "</span><br/>";
       }
     }
-    text.html(txtStr);
+    text.innerHTML = txtStr;
 
     // call registered displayInformation functions
     svgStr = "";
     for(const func of me.displayInformationFunctions) {
       svgStr = func(svgStr);
     }
-    vector.html(svgStr);
+    vector.innerHTML = svgStr;
   },
 
   /**
@@ -177,10 +177,9 @@ export var AtlasMakerDraw = {
         var c = me.ontologyValueToColor(data[i]);
         var alpha = (data[i]>0)?255:0;
         i = (y*me.atlasOffcn.width + x)*4;
-        me.atlasPix.data[i] = c[0];
-        me.atlasPix.data[i + 1] = c[1];
-        me.atlasPix.data[i + 2] = c[2];
-        me.atlasPix.data[i + 3] = alpha*me.alphaLevel;
+        if (i <= me.atlasPix.data.length - 4) {
+          me.atlasPix.data.set([...c, alpha*me.alphaLevel], i);
+        }
       }
     }
     me.atlasOfftx.putImageData(me.atlasPix, 0, 0);

--- a/view/atlasmaker/src/atlasmaker-ws.js
+++ b/view/atlasmaker/src/atlasmaker-ws.js
@@ -219,12 +219,14 @@ export var AtlasMakerWS = {
         me.info.volume=parseInt(vol)+" mm3";
 
         // setup download link
-        var link = me.container.find("span#download_atlas");
-        link.html([
-          "<a class='download' href='" + me.User.dirname + me.User.atlasFilename + "'>",
-          "<img src='" + me.hostname + "/img/download.svg' style='vertical-align:middle'/>",
-          "</a>" + atlas.name
-        ].join(''));
+        var link = me.container.querySelector("span#download_atlas");
+        if (link) {
+          link.innerHTML = [
+            "<a class='download' href='" + me.User.dirname + me.User.atlasFilename + "'>",
+            "<img src='" + me.hostname + "/img/download.svg' style='vertical-align:middle'/>",
+            "</a>" + atlas.name
+          ].join('');
+        }
 
         break;
       }

--- a/view/atlasmaker/src/atlasmaker.js
+++ b/view/atlasmaker/src/atlasmaker.js
@@ -254,27 +254,34 @@ var me = {
   _createOnscreenCanvases: function (elem) {
     // Set widget div (create one if none)
     if(typeof elem === 'undefined') {
-      me.container = $("<div class='atlasmaker'");
-      $(document.body).append(me.container);
+      me.container = document.getElementById("atlasmaker");
+      document.body.appendChild(me.container);
     } else {
       me.container = elem;
       if(me.debug) { console.log("Container: ", me.container); }
     }
     // Init drawing canvas
-    me.container.append('<div id="resizable"><canvas id="canvas" data-long-press-delay="500"></canvas></div>');
-    me.canvas = me.container.find('canvas').get(0);
+    me.container.innerHTML = '<div id="resizable"><canvas id="canvas" data-long-press-delay="500"></canvas></div>';
+    me.canvas = me.container.querySelector('canvas');
     me.context = me.canvas.getContext('2d');
+    var resizable = me.container.querySelector('#resizable');
 
     // Add a div to display the slice number
-    me.container.find("#resizable").append("<div id='text-layer'></div>");
+    var textLayer = document.createElement("div");
+    textLayer.id = 'text-layer';
+    resizable.appendChild(textLayer);
 
     // Add a div to display the vector layer
-    me.container.find("#resizable").append("<svg id='vector-layer'></svg>");
+    var vectorLayer = document.createElement("svg");
+    vectorLayer.id = 'vector-layer';
+    resizable.appendChild(vectorLayer);
 
     // Add the cursor (a small div)
-    me.container.find("#resizable").append("<div id='cursor'></div>");
+    var cursor = document.createElement("div");
+    cursor.id = 'cursor';
+    resizable.appendChild(cursor);
 
-    $('body').attr('data-toolbarDisplay', 'right');
+    document.body.setAttribute('data-toolbarDisplay', 'right');
 
     // Add precise cursor
     var isTouchArr = [];//["iPad","iPod"];
@@ -318,7 +325,7 @@ var me = {
     me.canvas.onmousedown = me.mousedown;
     me.canvas.onmousemove = me.mousemove;
     me.canvas.onmouseup = me.mouseup;
-    me.container.get(0).addEventListener('long-press', me.longpress);
+    me.container.addEventListener('long-press', me.longpress);
 
     // event connect: Connect event to respond to window resizing
     $(window).resize(function() {
@@ -338,7 +345,7 @@ var me = {
     } else {
       tools = toolsLight;
     }
-    me.container.append(tools);
+    me.container.insertAdjacentHTML("beforeend", tools);
 
     // event connect: get keyboard events
     $(document).keydown(function(e) { me.keyDown(e); });

--- a/view/atlasmaker/src/atlasmaker.js
+++ b/view/atlasmaker/src/atlasmaker.js
@@ -3,6 +3,8 @@
 import 'structjs';
 import './css/atlasmaker.css';
 
+import $ from 'jquery';
+
 import {AtlasMakerDraw} from './atlasmaker-draw.js';
 import {AtlasMakerIO} from './atlasmaker-io.js';
 import {AtlasMakerInteraction} from './atlasmaker-interaction.js';
@@ -10,7 +12,6 @@ import {AtlasMakerPaint} from './atlasmaker-paint.js';
 import {AtlasMakerUI} from './atlasmaker-ui.js';
 import {AtlasMakerWS} from './atlasmaker-ws.js';
 
-import $ from 'jquery';
 import Config from './../../../cfg.json';
 import toolsFull from './html/toolsFull.html';
 import toolsLight from './html/toolsLight.html';
@@ -31,7 +32,7 @@ var me = {
   // connection
   hostname: Config.hostname, // string, host url
   wshostname: Config.wshostname, // string, websocket url
-  secure: true, // wss used?
+  secure: Config.secure, // wss used?
 
   // canvas and drawing
   container: null, // [DOM element] where atlasmaker lives
@@ -261,7 +262,7 @@ var me = {
     }
     // Init drawing canvas
     me.container.append('<div id="resizable"><canvas id="canvas" data-long-press-delay="500"></canvas></div>');
-    me.canvas = me.container.find('canvas')[0];
+    me.canvas = me.container.find('canvas').get(0);
     me.context = me.canvas.getContext('2d');
 
     // Add a div to display the slice number
@@ -277,7 +278,7 @@ var me = {
 
     // Add precise cursor
     var isTouchArr = [];//["iPad","iPod"];
-    var curDevice = navigator.userAgent.split(/[(;]/)[1];
+    var [, curDevice] = navigator.userAgent.split(/[(;]/);
     if($.inArray(curDevice, isTouchArr)>=0) {
       me.flagUsePreciseCursor=true;
       me.initCursor();

--- a/view/atlasmaker/src/tools/adjust/index.js
+++ b/view/atlasmaker/src/tools/adjust/index.js
@@ -2,60 +2,61 @@
 import html from './index.html';
 
 // append HTML
-AtlasMakerWidget.container.find("#resizable").append(html);
+AtlasMakerWidget.container.querySelector("#resizable").innerHTML += html;
 
 // Transparency
-AtlasMakerWidget.slider($('.slider#alphaLevel'),function(x) {
-    $('#alphaLevel').data('val',x);
-    $('#alphaLevel .thumb')[0].style.left=x+'%';
-    AtlasMakerWidget.alphaLevel=x/100;
-    AtlasMakerWidget.drawImages();
+AtlasMakerWidget.slider($('.slider#alphaLevel'), function (x) {
+  $('#alphaLevel').data('val', x);
+  $('#alphaLevel .thumb')[0].style.left = x + '%';
+  AtlasMakerWidget.alphaLevel = x / 100;
+  AtlasMakerWidget.drawImages();
 });
-$('.slider#alphaLevel').data({max:100,val:50});
-$('#alphaLevel .thumb')[0].style.left=(AtlasMakerWidget.alphaLevel*100)+'%';
+$('.slider#alphaLevel').data({ max: 100, val: 50 });
+$('#alphaLevel .thumb')[0].style.left = (AtlasMakerWidget.alphaLevel * 100) + '%';
 
 // Brightness
-AtlasMakerWidget.slider($('.slider#minLevel'),function(x) {
-    $('#minLevel').data('val',x);
-    $('#minLevel .thumb')[0].style.left=x+'%';
+AtlasMakerWidget.slider($('.slider#minLevel'), function (x) {
+  $('#minLevel').data('val', x);
+  $('#minLevel .thumb')[0].style.left = x + '%';
 
-    var b=(2*x/100);
-    var c=(2*$('#maxLevel').data('val')/100);
-    $('#canvas').css({
-        'webkit-filter':'brightness('+b+') contrast('+c+')',
-        'filter':'brightness('+b+') contrast('+c+')'
-    });
+  var b = (2 * x / 100);
+  var c = (2 * $('#maxLevel').data('val') / 100);
+  $('#canvas').css({
+    'webkit-filter': 'brightness(' + b + ') contrast(' + c + ')',
+    'filter': 'brightness(' + b + ') contrast(' + c + ')'
+  });
 });
-$('.slider#minLevel').data({max:100,val:50});
-$('#minLevel .thumb')[0].style.left='50%';
+$('.slider#minLevel').data({ max: 100, val: 50 });
+$('#minLevel .thumb')[0].style.left = '50%';
 
 // Contrast
-AtlasMakerWidget.slider($('.slider#maxLevel'),function(x) {
-    $('#maxLevel').data('val',x);
-    $('#maxLevel .thumb')[0].style.left=x+'%';
+AtlasMakerWidget.slider($('.slider#maxLevel'), function (x) {
+  $('#maxLevel').data('val', x);
+  $('#maxLevel .thumb')[0].style.left = x + '%';
 
-    var b=(2*$('#minLevel').data('val')/100);
-    var c=(2*x/100);
-    $('#canvas').css({
-        'webkit-filter':'brightness('+b+') contrast('+c+')',
-        'filter':'brightness('+b+') contrast('+c+')'
-    });
+  var b = (2 * $('#minLevel').data('val') / 100);
+  var c = (2 * x / 100);
+  $('#canvas').css({
+    'webkit-filter': 'brightness(' + b + ') contrast(' + c + ')',
+    'filter': 'brightness(' + b + ') contrast(' + c + ')'
+  });
 });
-$('.slider#maxLevel').data({max:100,val:50});
-$('#maxLevel .thumb')[0].style.left='50%';
+$('.slider#maxLevel').data({ max: 100, val: 50 });
+$('#maxLevel .thumb')[0].style.left = '50%';
 
-var observer = new MutationObserver(function(mutations) {
-    mutations.forEach(function(mutation) {
-        if (mutation.attributeName === 'class') {
-            console.log('mutation',mutation);
-            var attributeValue = $(mutation.target).prop(mutation.attributeName);
-            if(attributeValue=='a sub')
-                $('#adjust').remove();
-                observer.disconnect();
-                // delete observer;
-        }
-    });
+var observer = new MutationObserver(function (mutations) {
+  mutations.forEach(function (mutation) {
+    if (mutation.attributeName === 'class') {
+      console.log('mutation', mutation);
+      var attributeValue = $(mutation.target).prop(mutation.attributeName);
+      if (attributeValue === 'a sub') {
+        $('#adjust').remove();
+      }
+      observer.disconnect();
+      // delete observer;
+    }
+  });
 });
 observer.observe($('#paintTool [title="Adjust"]')[0], {
-    attributes: true
+  attributes: true
 });

--- a/view/brainbox/src/brainbox.js
+++ b/view/brainbox/src/brainbox.js
@@ -91,10 +91,14 @@ export var BrainBox={
   initBrainBox: function initBrainBox() {
     var pr = new Promise(function(resolve, reject) {
       // Add AtlasMaker and friends
-      $("#stereotaxic").html('<div id="atlasmaker"></div>');
-      $("#atlasmaker").addClass('edit-mode');
+      var stereotaxic = document.getElementById("stereotaxic");
+      stereotaxic.innerHTML = '';
+      var atlasmaker = document.createElement("div");
+      atlasmaker.id = "atlasmaker";
+      atlasmaker.className = "edit-mode";
+      stereotaxic.appendChild(atlasmaker);
 
-      AtlasMakerWidget.initAtlasMaker($("#atlasmaker"))
+      AtlasMakerWidget.initAtlasMaker(atlasmaker)
         .then(function() {
           resolve();
         })

--- a/view/brainbox/src/pages/index-page.js
+++ b/view/brainbox/src/pages/index-page.js
@@ -8,8 +8,8 @@ import '../style/ui.css';
  * @returns {void}
  */
 function goToURL() {
-    const url = document.getElementById("url").value;
-    location.href = "/mri?url="+url;
+  const url = document.getElementById("url").value;
+  location.href = "/mri?url=" + url;
 }
 
 /**
@@ -17,46 +17,47 @@ function goToURL() {
  * @returns {void}
  */
 function testWebSockets() {
-console.log("testWebSockets");
-    return new Promise(function(resolve, reject) {
-        // var host = "wss://websocketstest.com/service";
-        var host = "wss://echo.websocket.org";
-        var ws;
+  console.log("testWebSockets");
 
-        if (window.WebSocket) {
-            ws=new window.WebSocket(host);
-        } else if (window.MozWebSocket) {
-            ws=new MozWebSocket(host);
-        } else {
-            reject(new Error("BrainBox requires access to WebSockets, but this web browser does not support them. Try Firefox, Chrome or Safari."));
-        }
-        ws.onopen = function() {
-            ws.close();
-            resolve("Connection ok");
-        };
-        ws.onerror = function(err) {
-console.log(err);
-            reject(new Error("BrainBox requires access to WebSockets, but your connection does not allow it. Ask your provider to allow WebSockets on port 8080"));
-        };
-    });
+  return new Promise(function (resolve, reject) {
+    // var host = "wss://websocketstest.com/service";
+    var host = "wss://echo.websocket.org";
+    var ws;
+
+    if (window.WebSocket) {
+      ws = new window.WebSocket(host);
+    } else if (window.MozWebSocket) {
+      ws = new MozWebSocket(host);
+    } else {
+      reject(new Error("BrainBox requires access to WebSockets, but this web browser does not support them. Try Firefox, Chrome or Safari."));
+    }
+    ws.onopen = function () {
+      ws.close();
+      resolve("Connection ok");
+    };
+    ws.onerror = function (err) {
+      console.log(err);
+      reject(new Error("BrainBox requires access to WebSockets, but your connection does not allow it. Ask your provider to allow WebSockets on port 8080"));
+    };
+  });
 }
 
 testWebSockets()
-  .then(function() {
-      console.log("Connection to websockets is ok");
+  .then(function () {
+    console.log("Connection to websockets is ok");
   })
-  .catch(function(m) {
-      alert(m);
+  .catch(function (m) {
+    alert(m);
   });
 
-for(const slide of Array.from(document.getElementsByClassName("slide"))) {
-    slide.style.height = window.innerHeight + 'px';
+for (const slide of Array.from(document.getElementsByClassName("slide"))) {
+  slide.style.height = window.innerHeight + 'px';
 }
 
 window.addEventListener('resize', () => {
-    for(const slide of document.getElementsByClassName("slide")) {
-        slide.style.height = window.innerHeight + 'px';
-    }
+  for (const slide of document.getElementsByClassName("slide")) {
+    slide.style.height = window.innerHeight + 'px';
+  }
 });
 
 // go to url button
@@ -64,13 +65,13 @@ document.getElementById("go").addEventListener('click', goToURL);
 
 // video settings
 var vid = document.getElementById("bgBrains");
-vid.onplaying = function() {
-    vid.playbackRate = 0.5;
+vid.onplaying = function () {
+  vid.playbackRate = 0.5;
 };
 
 // List of brains
 document.getElementById("list").addEventListener("change", () => {
-    document.getElementById("url").value = document.getElementById("list").value;
+  document.getElementById("url").value = document.getElementById("list").value;
 });
 
 document.querySelector("h2").style.marginLeft = 0;
@@ -78,32 +79,32 @@ document.querySelector("h2").style.opacity = 1;
 
 // Add URL loading
 document.getElementById("url").addEventListener("keyup", (e) => {
-    if (e.keyCode === 13) {
-        goToURL(e);
-    }
+  if (e.keyCode === 13) {
+    goToURL(e);
+  }
 });
 
 // Connect addProject button
 document.getElementById("addProject").addEventListener("click", () => {
-    location.href = "/project/new";
+  location.href = "/project/new";
 });
 
 // multiple div as slides
 var menuShowing = true;
 window.addEventListener("scroll", () => {
-    const y = window.pageYOffset;
-    if(y>100 && menuShowing) {
-        document.getElementById("menu").style.top = -32;
-        document.getElementById("menu").style.opacity = 0;
-        menuShowing = false;
+  const y = window.pageYOffset;
+  if (y > 100 && menuShowing) {
+    document.getElementById("menu").style.top = -32;
+    document.getElementById("menu").style.opacity = 0;
+    menuShowing = false;
 
-        document.getElementById("footer").style.display = "";
-    }
-    if(y<100 && !menuShowing) {
-        document.getElementById("menu").style.top = 0;
-        document.getElementById("menu").style.opacity = 1;
-        menuShowing = true;
-    }
+    document.getElementById("footer").style.display = "";
+  }
+  if (y < 100 && !menuShowing) {
+    document.getElementById("menu").style.top = 0;
+    document.getElementById("menu").style.opacity = 1;
+    menuShowing = true;
+  }
 });
 
 // intro.js test

--- a/view/brainbox/src/pages/project-new-page.js
+++ b/view/brainbox/src/pages/project-new-page.js
@@ -14,46 +14,53 @@ import * as DOMPurify from 'dompurify';
 
 import $ from 'jquery';
 
-var host = "wss://" + window.location.hostname + ":8080/";
+import Config from './../../../../cfg.json';
+
+var host;
+if(Config.secure) {
+  host = "wss://" + Config.wshostname;
+} else {
+  host = "ws://" + Config.wshostname;
+}
 let ws;
 if (window.WebSocket) {
-    ws = new WebSocket(host);
+  ws = new window.WebSocket(host);
 } else if (window.MozWebSocket) {
-    ws = new MozWebSocket(host);
+  ws = new window.MozWebSocket(host);
 }
-ws.onopen = function(msg) {
-    ws.send(JSON.stringify({"type":"autocompleteClient"}));
-}
-ws.onmessage = function(message) {
-    message = JSON.parse(message.data);
-    if (message.type === "projectNameQuery") {
-        if(message.metadata) {
-            $("#warning").html("The project <a><strong>"+message.metadata.shortname+"</strong></a> already exists");
-            $("#warning a").attr('href','/project/'+message.metadata.shortname);
-            $("#warning").show();
-            $("#createProject").css({'pointer-events':'none',opacity:0.5});
-        } else {
-            $("#warning").hide();
-            $("#createProject").css({'pointer-events':'auto',opacity:1});
-        }
-    }
-}
-
-$("#projectName").on('keyup',function(e) {
-    var name=DOMPurify.sanitize($("#projectName").val());
-    
-    // check if name is alphanumeric
-    if(/[^a-zA-Z0-9]+/.test(name) === true) {
-        $("#warning").html("The name <strong>"+name+"</strong> is not allowed. Project short names can only contain letters and numbers");
-        $("#warning").show();
-        $("#createProject").css({'pointer-events':'none', opacity:0.5});
+ws.onopen = function () {
+  ws.send(JSON.stringify({ "type": "autocompleteClient" }));
+};
+ws.onmessage = function (message) {
+  message = JSON.parse(message.data);
+  if (message.type === "projectNameQuery") {
+    if (message.metadata) {
+      $("#warning").html("The project <a><strong>" + message.metadata.shortname + "</strong></a> already exists");
+      $("#warning a").attr('href', '/project/' + message.metadata.shortname);
+      $("#warning").show();
+      $("#createProject").css({ 'pointer-events': 'none', opacity: 0.5 });
     } else {
-    // check if name already exists
-        ws.send(JSON.stringify({"type":"projectNameQuery", "metadata":{"name":name}}));
+      $("#warning").hide();
+      $("#createProject").css({ 'pointer-events': 'auto', opacity: 1 });
     }
+  }
+};
+
+$("#projectName").on('keyup', function () {
+  var name = DOMPurify.sanitize($("#projectName").val());
+
+  // check if name is alphanumeric
+  if (/[^a-zA-Z0-9]+/.test(name) === true) {
+    $("#warning").html("The name <strong>" + name + "</strong> is not allowed. Project short names can only contain letters and numbers");
+    $("#warning").show();
+    $("#createProject").css({ 'pointer-events': 'none', opacity: 0.5 });
+  } else {
+    // check if name already exists
+    ws.send(JSON.stringify({ "type": "projectNameQuery", "metadata": { "name": name } }));
+  }
 });
 
-$("#createProject").click(function cancelChanges(){location.pathname='/project/'+$("#projectName").val()+'/settings'});
-$("#cancelChanges").click(function cancelChanges(){location.pathname=projectURL});
+$("#createProject").click(function cancelChanges() { location.pathname = '/project/' + $("#projectName").val() + '/settings'; });
+$("#cancelChanges").click(function cancelChanges() { location.pathname = projectURL; });
 
-$("#addProject").click(function(){location="/project/new"});
+$("#addProject").click(function () { location = "/project/new"; });

--- a/view/brainbox/src/pages/project-page.js
+++ b/view/brainbox/src/pages/project-page.js
@@ -27,7 +27,7 @@ let file;
 let trTemplate;
 let objTemplate;
 let aParam;
-let hashOld;
+// let hashOld;
 
 function appendFilesToProject(list) {
   const i0 = projectInfo.files.list.length;
@@ -90,7 +90,7 @@ function queryFiles() {
 function saveAnnotations(param) {
   JSON.stringify(param.infoProxy); // update BrainBox.info from infoProxy
   AtlasMakerWidget.sendSaveMetadataMessage(BrainBox.info);
-  hashOld = BrainBox.hash(JSON.stringify(BrainBox.info));
+  // hashOld = BrainBox.hash(JSON.stringify(BrainBox.info));
 }
 
 /**
@@ -197,8 +197,8 @@ function loadProjectFile(index) {
           resolve();
         });
     } else {
-      var msg=AtlasMakerWidget.container.find("#text-layer");
-      msg.html("<text x='5' y='15' fill='white'>ERROR: File is unreadable</text>");
+      var msg=AtlasMakerWidget.container.querySelector("#text-layer");
+      msg.innerHTML = "<text x='5' y='15' fill='white'>ERROR: File is unreadable</text>";
       reject(new Error("ERROR: Cannot read data. The file is maybe corrupt?"));
     }
   });


### PR DESCRIPTION
<!-- Thank you for your contribution to BrainBox -->

<!-- Give a short title and description for your pull request: -->
Secure web-sockets are not easy to set up. I propose to preserve the support of non-secure web-sockets if not too difficult to maintain.

---
<!-- Run the tests. Replace each `[ ]` by `[X]` when the step is complete.-->
- [ ] These changes fix #__ (github issue number if applicable).
- [ X ] ```npm run mocha-test``` ran with full success.
- [ ] ```npm run mocha-test``` ran resulted in  failure in _____

<!-- Replace `__` with appropriate information: -->
- [ ] I implemented tests for the changes I made OR
- [ X ] These changes do not require tests because no new feature

<!-- Make sure that "Allow edits from maintainers" checkbox is checked.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification. -->


- [ X ] All BrainBox tools behave as expected:
except save button displays a message that user needs to login in case they are not (unless I missed it)
    * **KEYS**
        * right and left arrow keys
            - [ ] jump to next or previous slice within one brain, respectively
            - [ ] update the slider accordingly
            - [ ] update the slice number accordingly (upper left corner of the viewer window)
        * down and up arrow keys
            - [ ] jump to the next or previous brain within one project, respectively
            - [ ] update the selected subject in the annotation table
    * **TOOL BUTTONS**
        * minus
            - [ ] jumps to the previous slice within one brain
            - [ ] updates the slider accordingly
            - [ ] updates the slice number accordingly (upper left corner of the viewer window)
        * plus
            - [ ] jumps to the next slice within one brain
            - [ ] updates the slider accordingly
            - [ ] updates the slice number accordingly (upper left corner of the viewer window)
        * slider
            - [ ] updates slice view and slice number on the fly
        * sag / cor / axi buttons
            - [ ] switch view between the three orthogonal planes
        * show tool
            - [ ] when you click and drag in your browser window, this tool displays a cirlce at the position of your mouse click & drag as well as the user name in all browser windows connected to the same brain
        * the numbers at the bottom of the tool panel
            - [ ] change pencil size and eraser size accordingly
        * pencil tool
            - [ ] draws a line in the colour displayed in the color field
            - [ ] in combination with bucket tool filles a complete area with the chosen colour (be sure to have closed the contour line ;) Otherwise, the undo button will be your friend ;)
            - [ ] updates length and volume information (of what has been segmented) in the upper left corner of the viewer
        * erase tool
            - [ ] erases upon click drag from the annotation
            - [ ] in combination with the bucket tool erases the complete area of the color where you click
        * fill bucket tool
            * in combination with pencil tool
                - [ ] fills a complete area with the colour displayed in the colour field
            * in combination with erase tool
                - [ ] erases the complete area that is filled by the colour of where you click
        * colour field
            - [ ] displays the currently chosen colour to draw and fill
            - [ ] on click opens the set of colours available within the chosen label set where a new colour can be selected upon click
        * ruler tool
            - [ ] measures the distance between start and end of your defined path
                - [ ] points of mouse click appear and stay visible until you hit return key (this functionality is currently broken!) (you can click as many points as you wish to define the path you are interested in)
                - [ ] on return key, BrainBox will print the distance into the chat field (the ruler tool seems to be currently broken!!!)
        * adjust tool
            - [ ] slide opacity of overlaid annotation from 0 to 100%
            - [ ] increase or decrease brightness of the underlying MRI data
            - [ ] increase or decrease the contrast of the underlying MRI data
        * eyedropper tool
            - [ ] updates the colour field in the tool panel
            - [ ] displays/updates the region name in the upper left corner of the viewer
        * undo tool
            - [ ] undoes the user's actions in reverse chronological order and currently has the bug that it even undoes actions in slices you are currently not seeing! and there is currently no redo...
        * save button
            - [ ] saves the annotation of the data set into the data base
            - [ ] displays a message that user needs to login in case they are not
            - [ ] display a message `Atlas saved Wed Oct 18 2017 12:49:12 GMT+0200 (CEST)`


