### PR TITLE
fix user projects displayed several times in the user page

### DIFF
--- a/test/integration/client.js
+++ b/test/integration/client.js
@@ -125,7 +125,9 @@ describe('TESTING CLIENT-SIDE RENDERING', function () {
         U.serverURL + '/user/' + U.userFoo.nickname,
         filename
       );
+      const nbProjects = await page.evaluate(() => document.getElementById("projects").tBodies[0].rows.length);
       assert(diff < npixels1pct, `${diff} pixels were different in ${filename}`);
+      assert.strictEqual(nbProjects, 1);
     }).timeout(U.noTimeout);
 
     // CLOSE

--- a/test/runner.js
+++ b/test/runner.js
@@ -5,6 +5,7 @@ before(async function () {
   // eslint-disable-next-line no-invalid-this
   this.timeout(U.longTimeout);
   await U.insertUser(U.userFoo);
+  await U.insertProject(U.privateProjectTest);
   await U.insertProject(U.projectTest);
   await U.insertTestTokenForUser("foo");
   await browser.init();
@@ -15,6 +16,7 @@ before(async function () {
 after(async function () {
   await U.removeUser(U.userFoo.nickname);
   await U.removeProject(U.projectTest.shortname);
+  await U.removeProject(U.privateProjectTest.shortname);
   await U.removeTestTokenForUser("foo");
   await browser.close();
 });

--- a/test/unit/data.slices.spec.js
+++ b/test/unit/data.slices.spec.js
@@ -106,8 +106,8 @@ describe('Data Slices ', function() {
         },
         db: db
       };
-      const files = await dataSlices.getProjectsSlice(req, 0, 1);
-      assert.strictEqual(files.length, 1);
+      const files = await dataSlices.getProjectsSlice(req, 0, 10);
+      assert.notStrictEqual(files.length, 0);
     });
 
     it('should return the number of files based on length', async function() {

--- a/test/utils.js
+++ b/test/utils.js
@@ -98,6 +98,33 @@ const projectTest = {
   modifiedBy: "foo"
 };
 
+const privateProjectTest = {
+  name: "Private Test Project",
+  shortname: "privatetestproject",
+  url: "https://testproject.org",
+  brainboxURL: "/project/privatetestproject",
+  created: (new Date()).toJSON(),
+  owner: "foo",
+  collaborators: {
+    list: [
+      {
+        userID: "anyone",
+        access: {
+          collaborators: "none",
+          annotations: "none",
+          files: "none"
+        },
+        username: "anyone",
+        name: "Any User"
+      }
+    ]
+  },
+  description: "A private test project used for checking the authorization process.",
+  modified: (new Date()).toJSON(),
+  modifiedBy: "foo"
+};
+
+
 const currentDirectory = function () {
   console.log("Current directory:", __dirname);
   exec('ls -l', (error, stdout) => {
@@ -229,6 +256,7 @@ module.exports = {
   userFooB,
   userBarB,
   projectTest,
+  privateProjectTest,
   testToken,
   removeMRI,
   currentDirectory,

--- a/test/utils.js
+++ b/test/utils.js
@@ -119,6 +119,12 @@ const privateProjectTest = {
       }
     ]
   },
+  files: {
+    list: []
+  },
+  annotations: {
+    list: []
+  },
   description: "A private test project used for checking the authorization process.",
   modified: (new Date()).toJSON(),
   modifiedBy: "foo"

--- a/view/brainbox/src/pages/user-page.js
+++ b/view/brainbox/src/pages/user-page.js
@@ -13,7 +13,6 @@ import '../style/user-style.css';
 import $ from 'jquery';
 // import * as tw from '../twoWayBinding.js';
 
-// eslint-disable-next-line no-unused-vars
 var cursorProjects = 0;
 
 const appendProjects = (list) => {
@@ -43,7 +42,7 @@ const appendProjects = (list) => {
 };
 
 const queryProjects = () => {
-  $.getJSON(`/user/json/${nickname}/projects`, {start:userInfo.projects.length, length:100})
+  $.getJSON(`/user/json/${nickname}/projects`, { start: cursorProjects, length: 100 })
     .then(function(res) {
       if(res.success & res.list.length > 0) {
         appendProjects(res.list);


### PR DESCRIPTION
<!-- Thank you for your contribution to BrainBox -->

<!-- Give a short title and description for your pull request: -->
fix issue #305
---
<!-- Run the tests. Replace each `[ ]` by `[X]` when the step is complete.-->
- [ x] These changes fix #305 (github issue number if applicable).
- [x ] ```npm run mocha-test``` ran with full success.
- [ ] ```npm run mocha-test``` ran resulted in  failure in _____

<!-- Replace `__` with appropriate information: -->
- [ x] I implemented tests for the changes I made OR
- [ ] These changes do not require tests because _____

<!-- Make sure that "Allow edits from maintainers" checkbox is checked.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification. -->


- [ ] All BrainBox tools behave as expected:
    * **KEYS**
        * right and left arrow keys
            - [ ] jump to next or previous slice within one brain, respectively
            - [ ] update the slider accordingly
            - [ ] update the slice number accordingly (upper left corner of the viewer window)
        * down and up arrow keys
            - [ ] jump to the next or previous brain within one project, respectively
            - [ ] update the selected subject in the annotation table
    * **TOOL BUTTONS**
        * minus
            - [ ] jumps to the previous slice within one brain
            - [ ] updates the slider accordingly
            - [ ] updates the slice number accordingly (upper left corner of the viewer window)
        * plus
            - [ ] jumps to the next slice within one brain
            - [ ] updates the slider accordingly
            - [ ] updates the slice number accordingly (upper left corner of the viewer window)
        * slider
            - [ ] updates slice view and slice number on the fly
        * sag / cor / axi buttons
            - [ ] switch view between the three orthogonal planes
        * show tool
            - [ ] when you click and drag in your browser window, this tool displays a cirlce at the position of your mouse click & drag as well as the user name in all browser windows connected to the same brain
        * the numbers at the bottom of the tool panel
            - [ ] change pencil size and eraser size accordingly
        * pencil tool
            - [ ] draws a line in the colour displayed in the color field
            - [ ] in combination with bucket tool filles a complete area with the chosen colour (be sure to have closed the contour line ;) Otherwise, the undo button will be your friend ;)
            - [ ] updates length and volume information (of what has been segmented) in the upper left corner of the viewer
        * erase tool
            - [ ] erases upon click drag from the annotation
            - [ ] in combination with the bucket tool erases the complete area of the color where you click
        * fill bucket tool
            * in combination with pencil tool
                - [ ] fills a complete area with the colour displayed in the colour field
            * in combination with erase tool
                - [ ] erases the complete area that is filled by the colour of where you click
        * colour field
            - [ ] displays the currently chosen colour to draw and fill
            - [ ] on click opens the set of colours available within the chosen label set where a new colour can be selected upon click
        * ruler tool
            - [ ] measures the distance between start and end of your defined path
                - [ ] points of mouse click appear and stay visible until you hit return key (this functionality is currently broken!) (you can click as many points as you wish to define the path you are interested in)
                - [ ] on return key, BrainBox will print the distance into the chat field (the ruler tool seems to be currently broken!!!)
        * adjust tool
            - [ ] slide opacity of overlaid annotation from 0 to 100%
            - [ ] increase or decrease brightness of the underlying MRI data
            - [ ] increase or decrease the contrast of the underlying MRI data
        * eyedropper tool
            - [ ] updates the colour field in the tool panel
            - [ ] displays/updates the region name in the upper left corner of the viewer
        * undo tool
            - [ ] undoes the user's actions in reverse chronological order and currently has the bug that it even undoes actions in slices you are currently not seeing! and there is currently no redo...
        * save button
            - [ ] saves the annotation of the data set into the data base
            - [ ] displays a message that user needs to login in case they are not
            - [ ] display a message `Atlas saved Wed Oct 18 2017 12:49:12 GMT+0200 (CEST)`


