### PR TITLE
Make sure user can't patch existing MRI through websockets (#315 follow-up)

### DIFF
--- a/controller/atlasmakerServer/atlasmakerServer.js
+++ b/controller/atlasmakerServer/atlasmakerServer.js
@@ -1242,6 +1242,16 @@ data.vox_offset: ${me.Brains[i].data.vox_offset}
         if (data.method === "patch") {
         // deal with patches
 
+          const addingORremovingLayerOrAnnotations = data.patch.some((operation) => {
+            if (operation.path === null) { return false; }
+
+            return (operation.op === 'remove' || operation.op === 'add') &&
+                   (operation.path.startsWith('/mri/atlas/') || operation.path.startsWith('/mri/annotations/'));
+          });
+          if (addingORremovingLayerOrAnnotations) {
+            throw new Error('Refusing to apply patch - cannot directly remove or add annotation layers on MRI files');
+          }
+
           // get original object from db
           let ret = await db.get('mri').findOne({ source: json.source, backup: { $exists: 0 } }, { _id: 0 });
           delete ret._id;

--- a/templates/mri.mustache
+++ b/templates/mri.mustache
@@ -54,7 +54,7 @@
                             <table>
                                 <tr>
                                 <th><b>Name</b></th>
-                                <td><span id="name" contentEditable=true class="noEmpty"></span></td>
+                                <td><span id="name" class="noEmpty"></span></td>
                                 </tr>
                             
                                 <tr>
@@ -98,11 +98,6 @@
                             </thead>
                             <tbody></tbody>
                             </table>
-                            <div style="text-align:right">
-                                <span id="textAnnotationMessage"></span>
-                                <img id="addTextAnnotation" title="add text annotation" alt="add text annotation" class="button" style="width:19px; height:19px" src="/img/plus-square.svg"/>
-                                <img id="removeTextAnnotation" title="remove text annotation" alt="remove text annotation" class="button" style="width:19px; height:19px" src="/img/minus-square.svg"/>
-                            </div>
 
                         </div>
                     </div>


### PR DESCRIPTION
To make sure annotations cannot be edited or removed through websockets I've prevented patches that add / remove layers or text annotations to be applied on MRIs.

It can now only be done from a project settings page.

I've not covered the case where a user send a whole object instead of a patch to the websocket server, but from what I understand this needs to be deprecated. 
