### PR TITLE
Bump nwl-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "multer": "^1.4.2",
     "mustache-express": "^1.3.0",
     "neuroweblab": "github:neuroanatomy/neuroweblab",
-    "nwl-components": "^0.0.12",
+    "nwl-components": "^0.0.16",
     "pako": "^1.0.11",
     "passport": "^0.4.1",
     "passport-github": "^1.1.0",


### PR DESCRIPTION
The version of nwl-components was lagging behind and that there was a bugfix related to the username field that was not taken into account ([fixed in 0.0.14](https://github.com/neuroanatomy/nwl-components/commit/6160c0b7d248493f30164a9b2669c26a2a1c43d9)).

I've added an extra check in the nwl-components repository to make sure we're always saving the userID, and rely on the userID if we can't pull the usual username field.