### PR TITLE
Bump nwl-components (bis)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "multer": "^1.4.2",
     "mustache-express": "^1.3.0",
     "neuroweblab": "github:neuroanatomy/neuroweblab",
-    "nwl-components": "^0.0.16",
+    "nwl-components": "^0.0.17",
     "pako": "^1.0.11",
     "passport": "^0.4.1",
     "passport-github": "^1.1.0",


### PR DESCRIPTION
I went ahead too quickly and wrote `collaborator[userID]` instead of `collaborator.userID` in nwl-components.
Tested locally removing the actual username field from the database.

(follow up to https://github.com/neuroanatomy/BrainBox/pull/334)