### PR TITLE
fix promise not awaited when inserting mri names

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,8 @@
                 "--no-timeout"
             ],
             "env": {
-                "LOCALSIGNIN": "true"
+                "LOCALSIGNIN": "true",
+                "MONGODB": "127.0.0.1:27017/brainbox_test"
             }
         }
     ]

--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ var compression = require('compression');
 const path = require('path');
 const favicon = require('serve-favicon');
 const logger = require('morgan');
-const tracer = require('tracer').console({format: '[{{file}}:{{line}}]  {{message}}'});
+const tracer = require('tracer').console({ format: '[{{file}}:{{line}}]  {{message}}' });
 const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
 const mustacheExpress = require('mustache-express');
@@ -31,7 +31,7 @@ const DOCKER_DEVELOP = process.env.DEVELOP;
 if (DOCKER_DB) {
   MONGO_DB = DOCKER_DB.replace('tcp://', '') + '/brainbox';
 } else {
-  MONGO_DB = 'localhost:27017/brainbox'; //process.env.MONGODB;
+  MONGO_DB = process.env.MONGODB || 'localhost:27017/brainbox';
 }
 
 /** @todo Handle the case when MongoDB is not installed */
@@ -62,8 +62,8 @@ if (DOCKER_DEVELOP === '1') {
 const start = async function () {
   const app = express();
 
-  app.use(bodyParser.json({limit: '50mb'}));
-  app.use(bodyParser.urlencoded({limit: '50mb', extended: true}));
+  app.use(bodyParser.json({ limit: '50mb' }));
+  app.use(bodyParser.urlencoded({ limit: '50mb', extended: true }));
 
   /*
   Use the NeuroWebLab (NWL) module for authentication.
@@ -85,7 +85,7 @@ const start = async function () {
   //========================================================================================
   // Allow CORS
   //========================================================================================
-  app.use(function(req, res, next) {
+  app.use(function (req, res, next) {
     res.header('Access-Control-Allow-Origin', '*');
     res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
     next();
@@ -136,7 +136,7 @@ const start = async function () {
       key: await fs.promises.readFile(Config.ssl_key),
       cert: await fs.promises.readFile(Config.ssl_cert)
     };
-    if(Config.ssl_chain) {
+    if (Config.ssl_chain) {
       options.ca = await fs.promises.readFile(Config.ssl_chain);
     }
     atlasmakerServer.server = https.createServer(options, app);
@@ -163,33 +163,34 @@ const start = async function () {
   //========================================================================================
   // catch 404 and forward to error handler
   app.use(function (req, res, next) {
-    var err = new Error('Not Found');
-    err.status = 404;
-    next(err);
+    console.log('Not found URL requested: ' + req.url);
+    next();
   });
 
-  // development error handler
-  // will print stacktrace
-  if (app.get('env') === 'development') {
-    app.use(function (err, req, res) {
-      res.status(err.status || 500);
-      res.render('error', {
-        message: err.message,
-        error: err
-      });
-    });
-  }
-  // production error handler
-  // no stacktraces leaked to user
-  app.use(function (err, req, res) {
-    res.status(err.status || 500);
-    res.render('error', {
-      message: err.message,
-      error: {}
-    });
-  });
+  // the following middlewares will not be used by express as we need to pass 4 arguments to
+  // the use method to handle express errors: https://expressjs.com/fr/guide/error-handling.html
+  // // development error handler
+  // // will print stacktrace
+  // if (app.get('env') === 'development') {
+  //   app.use(function (err, req, res) {
+  //     res.status(err.status || 500);
+  //     res.render('error', {
+  //       message: err.message,
+  //       error: err
+  //     });
+  //   });
+  // }
+  // // production error handler
+  // // no stacktraces leaked to user
+  // app.use(function (err, req, res) {
+  //   res.status(err.status || 500);
+  //   res.render('error', {
+  //     message: err.message,
+  //     error: {}
+  //   });
+  // });
 
   return { app, server, atlasmakerServer };
 };
 
-module.exports = {start};
+module.exports = { start };

--- a/controller/mri/mri.controller.js
+++ b/controller/mri/mri.controller.js
@@ -11,6 +11,8 @@ const dataSlices = require('../dataSlices/dataSlices.js');
 const { AccessType, AccessLevel } = require('neuroweblab');
 const BrainboxAccessControlService = require('../../services/BrainboxAccessControlService');
 const _ = require('lodash');
+const AsyncLock = require('async-lock');
+const lock = new AsyncLock();
 
 const downloadQueue = {};
 let atlasmakerServer;
@@ -92,20 +94,20 @@ const validatorPost = function (req, res, next) {
 --------------------- */
 // @todo Change this function callback into a promise
 // eslint-disable-next-line max-statements
-const downloadMRI = async function(myurl, req) {
+const downloadMRI = async function (myurl, req) {
   console.log('downloadMRI');
   const hash = crypto
     .createHash('md5')
     .update(myurl)
     .digest('hex');
 
-  const mridb = await req.db.get('mri').findOne({source: myurl, backup: {$exists: 0}});
+  const mridb = await req.db.get('mri').findOne({ source: myurl, backup: { $exists: 0 } });
   console.log('mridb:', mridb);
   let filename;
   if (!mridb || !mridb.filename) {
     filename = sanitize(url.parse(myurl).pathname.split('/').pop());
   } else {
-    ({filename} = mridb);
+    ({ filename } = mridb);
   }
   let dest = req.dirname + '/public/data/' + hash + '/' + filename;
   console.log('   source:', myurl);
@@ -122,7 +124,7 @@ const downloadMRI = async function(myurl, req) {
   let cur = 0;
 
   return new Promise(function (resolve, reject) {
-    request({uri: myurl, followAllRedirects: true, rejectUnauthorized : false})
+    request({ uri: myurl, followAllRedirects: true, rejectUnauthorized: false })
       .on('error', (err) => {
         console.log('ERROR in downloadMRI', err);
         reject(err);
@@ -162,7 +164,7 @@ const downloadMRI = async function(myurl, req) {
           .then((mri) => {
             // Create json file for new dataset
             let ip = '';
-            if(typeof req.headers['x-forwarded-for'] !== 'undefined') {
+            if (typeof req.headers['x-forwarded-for'] !== 'undefined') {
               ip = req.headers['x-forwarded-for'];
             } else if (req.connection.remoteAddress !== 'undefined') {
               ip = req.connection.remoteAddress;
@@ -173,8 +175,8 @@ const downloadMRI = async function(myurl, req) {
             }
 
             let username;
-            if(req.isAuthenticated()) {
-              ({username} = req.user);
+            if (req.isAuthenticated()) {
+              ({ username } = req.user);
             } else {
               username = ip;
             }
@@ -278,9 +280,10 @@ const mri = async function (req, res) {
     // also query projects that set this MRI as a source
     projects.push(...await req.db.get('project').find({
       $or: [
-        { 'files.list': {$eq: myurl }},
-        { 'files.list.source': {$eq: myurl }}
-      ]}
+        { 'files.list': { $eq: myurl } },
+        { 'files.list.source': { $eq: myurl } }
+      ]
+    }
     ));
 
     // set access to volume annotations
@@ -324,7 +327,7 @@ const apiMriPost = async function (req, res) {
   try {
     // eslint-disable-next-line no-new
     new URL(myurl);
-  } catch(err) {
+  } catch (err) {
     res.send('Invalid URL!');
 
     return;
@@ -412,7 +415,10 @@ const apiMriPost = async function (req, res) {
         console.log('Download succeeded. Insert in DB, remove from queue');
         obj.success = true;
 
-        return req.db.get('mri').insert(obj);
+        return lock.acquire('mri', async function () {
+          await req.db.get('mri').update({ source: myurl }, { $set: { backup: true } }, { multi: true });
+          await req.db.get('mri').insert(obj);
+        });
       })
         .then(() => {
           // downloadQueue[myurl] = obj;
@@ -567,7 +573,7 @@ const apiMriGet = async function (req, res) {
 };
 
 // eslint-disable-next-line func-style
-const reset = async function reset(req, res) {
+const reset = async function reset (req, res) {
   const myurl = req.query.url;
   const hash = crypto.createHash('md5').update(myurl)
     .digest('hex');
@@ -582,7 +588,7 @@ const reset = async function reset(req, res) {
     });
   console.log(mridb);
   let filename;
-  if (mridb) { ({filename} = mridb); }
+  if (mridb) { ({ filename } = mridb); }
   const mrires = await atlasmakerServer.getBrainAtPath('/data/' + hash + '/' + filename)
     .catch((err) => {
       console.log('ERROR:', err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "multer": "^1.4.2",
         "mustache-express": "^1.3.0",
         "neuroweblab": "github:neuroanatomy/neuroweblab",
-        "nwl-components": "^0.0.12",
+        "nwl-components": "^0.0.17",
         "pako": "^1.0.11",
         "passport": "^0.4.1",
         "passport-github": "^1.1.0",
@@ -9445,14 +9445,16 @@
       }
     },
     "node_modules/nwl-components": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/nwl-components/-/nwl-components-0.0.12.tgz",
-      "integrity": "sha512-Qbce+RwJB1N0FBx4JYfNaTMcBA0sz00bpv2hJa6/4/FW+HP6RYo05Jmg/M6e52Kc9J1yIP/qHMtM25GxEasFeg==",
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/nwl-components/-/nwl-components-0.0.17.tgz",
+      "integrity": "sha512-fScHc9BrWXFmE653AYwZIY0sTvcwmMf1qaUtGkd/mnXSxX9FybW5c9krA97/pIZg7dii20nmLTSzbV7Ol6FJ4A==",
       "dependencies": {
+        "dompurify": "^2.3.6",
         "jdenticon": "^3.1.1",
         "lodash-es": "^4.17.21",
         "md5": "^2.3.0",
-        "nanoid": "^3.3.1"
+        "nanoid": "^3.3.1",
+        "splitpanes": "^3.1.0"
       },
       "peerDependencies": {
         "vue": "^3.2.25"
@@ -12122,6 +12124,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/splitpanes": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/splitpanes/-/splitpanes-3.1.1.tgz",
+      "integrity": "sha512-VUkxDJfIGSvTM/fm/+OSrx8ha9URwE/9B8FPvfzoBuAxVELIHBWpsfnJXIXv77zVwuex//QQL4kTU9SDBPeHjA=="
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -22342,14 +22349,16 @@
       }
     },
     "nwl-components": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/nwl-components/-/nwl-components-0.0.12.tgz",
-      "integrity": "sha512-Qbce+RwJB1N0FBx4JYfNaTMcBA0sz00bpv2hJa6/4/FW+HP6RYo05Jmg/M6e52Kc9J1yIP/qHMtM25GxEasFeg==",
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/nwl-components/-/nwl-components-0.0.17.tgz",
+      "integrity": "sha512-fScHc9BrWXFmE653AYwZIY0sTvcwmMf1qaUtGkd/mnXSxX9FybW5c9krA97/pIZg7dii20nmLTSzbV7Ol6FJ4A==",
       "requires": {
+        "dompurify": "^2.3.6",
         "jdenticon": "^3.1.1",
         "lodash-es": "^4.17.21",
         "md5": "^2.3.0",
-        "nanoid": "^3.3.1"
+        "nanoid": "^3.3.1",
+        "splitpanes": "^3.1.0"
       },
       "dependencies": {
         "canvas-renderer": {
@@ -24479,6 +24488,11 @@
       "requires": {
         "extend-shallow": "^3.0.0"
       }
+    },
+    "splitpanes": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/splitpanes/-/splitpanes-3.1.1.tgz",
+      "integrity": "sha512-VUkxDJfIGSvTM/fm/+OSrx8ha9URwE/9B8FPvfzoBuAxVELIHBWpsfnJXIXv77zVwuex//QQL4kTU9SDBPeHjA=="
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,11 @@
     "dev-brainbox": "webpack --mode production --config webpack.brainbox.config.js && cp view/brainbox/dist/brainbox.js public/lib/brainbox.js",
     "dev-pages": "webpack --mode development --config webpack.pages.config.js && cp view/brainbox/dist/*-page.js public/js/",
     "dev": "npm run dev-atlasmaker && npm run dev-atlasmaker-tools && npm run dev-brainbox && npm run dev-pages",
-    "test-unit": "nyc --report-dir test/unit/coverage mocha --timeout 5000 ./test/runner.js test/unit/*.js",
-    "test-integration": "cross-env LOCALSIGNIN=true nyc --report-dir test/integration/coverage mocha --timeout 5000 ./test/runner.js test/integration/*.js",
-    "mocha-test": "cross-env LOCALSIGNIN=true nyc mocha --timeout 5000 ./test/runner.js test/unit/*.js test/integration/*.js",
+    "test-unit": "cross-env MONGODB='127.0.0.1:27017/brainbox_test' nyc --report-dir test/unit/coverage mocha --timeout 5000 ./test/runner.js test/unit/*.js",
+    "test-integration": "cross-env MONGODB='127.0.0.1:27017/brainbox_test' LOCALSIGNIN=true nyc --report-dir test/integration/coverage mocha --timeout 5000 ./test/runner.js test/integration/*.js",
+    "mocha-test": "cross-env MONGODB='127.0.0.1:27017/brainbox_test' LOCALSIGNIN=true nyc mocha --timeout 5000 ./test/runner.js test/unit/*.js test/integration/*.js",
     "lint": "eslint .",
     "test": "docker exec brainbox_web_1 /bin/bash -c 'cd /brainbox && npm run mocha-test'",
-    "coverage": "nyc mocha --exit ./test/runner.js test/unit/*.js test/integration/*.js",
     "prepare": "husky install"
   },
   "dependencies": {

--- a/test/integration/permissions.js
+++ b/test/integration/permissions.js
@@ -112,50 +112,50 @@ describe('TESTING PERMISSIONS', function () {
   describe('Test specific edit / add / remove permissions of logged users', function() {
 
     const projects = {};
-    const setupProjectWithAccess = (access, name) => {
+    const setupProjectWithAccess = function (access, name) {
       const project = U.createProjectWithPermission(name, access);
       projects[project.name] = project;
-      U.insertProject(project);
+
+      return U.insertProject(project);
     };
 
-    before(function () {
-      ['none', 'view'].forEach((access) => {
-        setupProjectWithAccess(
+    before(async function () {
+      await Promise.all(['none', 'view'].map((acs) => (async function (access) {
+        await setupProjectWithAccess(
           { collaborators: access, files: 'edit' },
           `collaborators${access}filesedit`
         );
-        setupProjectWithAccess(
+        await setupProjectWithAccess(
           { collaborators: 'edit', files: access },
           `collaboratorseditfiles${access}`
         );
-      });
-      ['edit', 'add', 'remove'].forEach((access) => {
-        setupProjectWithAccess(
+      }(acs))));
+      await Promise.all(['edit', 'add', 'remove'].map((acs) => (async function (access) {
+        await setupProjectWithAccess(
           { collaborators: access, files: 'none' },
           `collaborators${access}filesnone`
         );
-        setupProjectWithAccess(
+        await setupProjectWithAccess(
           { collaborators: access, files: 'edit' },
           `collaborators${access}filesedit`
         );
-        setupProjectWithAccess(
+        await setupProjectWithAccess(
           { collaborators: 'edit', files: access },
           `collaboratorseditfiles${access}`
         );
-      });
-      ['none', 'view', 'add', 'edit', 'remove'].forEach((access) => {
-        setupProjectWithAccess(
+      }(acs))));
+      await Promise.all(['none', 'view', 'add', 'edit', 'remove'].map((acs) => (async function (access) {
+        await setupProjectWithAccess(
           { collaborators: 'edit', files: 'edit', annotations: access },
           `collaboratorseditfileseditannotations${access}`
         );
-      });
-
+      }(acs))));
     });
 
-    after(function() {
-      Object.keys(projects).forEach((shortname) => {
-        U.removeProject(shortname);
-      });
+    after(async function() {
+      await Promise.all(Object.keys(projects).map((shortname) =>
+        U.removeProject(shortname)
+      ));
 
     });
 
@@ -477,7 +477,7 @@ describe('TESTING PERMISSIONS', function () {
       it(`Checks that collaborators cannot remove project files if set to add (${userStatus})`, async function() {
         let project = U.createProjectWithPermission('permissionTest', { files: 'add' });
         projects.permissionTest = project;
-        U.insertProject(project);
+        await U.insertProject(project);
 
         const initialProjectState = _.cloneDeep(project);
         project = _.cloneDeep(project);

--- a/test/integration/project.controller.test.js
+++ b/test/integration/project.controller.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const chai = require('chai');
-var {assert} = chai;
+var { assert } = chai;
 const chaiHttp = require('chai-http');
 chai.use(chaiHttp);
 const U = require('../utils.js');
@@ -10,17 +10,17 @@ describe('TESTING THE /project ROUTE', function () {
   // eslint-disable-next-line no-invalid-this
   this.timeout(U.longTimeout);
 
-  before( async function () {
+  before(async function () {
     // add one MRI
     let shouldContinue = true;
-    while(shouldContinue) {
+    while (shouldContinue) {
       // eslint-disable-next-line no-await-in-loop
       const res = await chai.request(U.serverURL).post('/mri/json')
         .send({
           url: U.localBertURL,
           token: U.testToken + U.userFoo.nickname
         });
-      const {body} = res;
+      const { body } = res;
       // console.log(body);
       shouldContinue = (body.success !== true);
 
@@ -38,13 +38,13 @@ describe('TESTING THE /project ROUTE', function () {
 
     it('get("/project/json/") should get an error message requesting page', async function () {
       const { body } = await chai.request(U.serverURL).get('/project/json/');
-      const expected = {error: 'Provide the parameter \'page\''};
+      const expected = { error: 'Provide the parameter \'page\'' };
       assert.deepEqual(body, expected);
     });
 
     it('get("/project/json?page=0") should return an array', async function () {
       const { body } = await chai.request(U.serverURL).get('/project/json?page=0')
-        .query({page: 0});
+        .query({ page: 0 });
       assert(Array.isArray(body));
     });
 
@@ -54,7 +54,7 @@ describe('TESTING THE /project ROUTE', function () {
     });
 
     it('get("/project/json/test") should return an object with appropriate keys', async function () {
-      const {body} = await chai.request(U.serverURL).get(`/project/json/${U.projectTest.shortname}`);
+      const { body } = await chai.request(U.serverURL).get(`/project/json/${U.projectTest.shortname}`);
       const expectedKeys = [
         'name', 'shortname', 'url', 'brainboxURL', 'created', 'owner',
         'collaborators', 'files', 'annotations', 'description',
@@ -64,33 +64,39 @@ describe('TESTING THE /project ROUTE', function () {
     });
 
     it('get("/project/json/test/files") should return an array with >=1 file', async function () {
-      const {body} = await chai.request(U.serverURL)
+      const { body } = await chai.request(U.serverURL)
         .get(`/project/json/${U.projectTest.shortname}/files`)
-        .query({start: 0, length: 10});
+        .query({ start: 0, length: 10 });
       assert.isArray(body);
       assert.isAtLeast(body.length, 1);
     });
 
     it('get("/project/json/test/files") should return objects with appropriate keys', async function () {
-      const {body} = await chai.request(U.serverURL)
+      const { body } = await chai.request(U.serverURL)
         .get(`/project/json/${U.projectTest.shortname}/files`)
-        .query({start: 0, length: 10});
+        .query({ start: 0, length: 10 });
+      // only the first mri was fetched, dim info can be missing for the others
       const expectedKeys1 = [
         '_id', 'filename', 'success', 'source', 'url', 'included',
         'dim', 'pixdim', 'voxel2world', 'worldOrigin',
         'owner', 'mri', 'modified', 'modifiedBy', 'name'
       ];
-      const expectedKeys2 = ['source', 'name'];
+      const expectedKeys2 = [
+        '_id', 'filename', 'source', 'url', 'included',
+        'owner', 'mri', 'modified', 'modifiedBy', 'name'
+      ];
       // console.log(body);
       assert.isArray(body);
       assert.containsAllKeys(body[0], expectedKeys1);
-      assert.containsAllKeys(body[4], expectedKeys2);
+      for (let i = 1; i < 5; i++) {
+        assert.containsAllKeys(body[i], expectedKeys2);
+      }
     });
 
     it('get("/project/json/test/files") should return only sources and names if required', async function () {
       const { body } = await chai.request(U.serverURL)
         .get(`/project/json/${U.projectTest.shortname}/files`)
-        .query({start: 0, length: 10, names: true});
+        .query({ start: 0, length: 10, names: true });
       assert.isArray(body);
       assert.hasAllKeys(body[0], ['source', 'name']);
     });
@@ -101,9 +107,9 @@ describe('TESTING THE /project ROUTE', function () {
         .query({
           url: U.localBertURL
         });
-      const {body} = res;
+      const { body } = res;
       const dirPath = './public' + body.url;
-      await U.removeMRI({dirPath, srcURL: U.localBertURL});
+      await U.removeMRI({ dirPath, srcURL: U.localBertURL });
     });
   });
 });

--- a/test/runner.js
+++ b/test/runner.js
@@ -6,17 +6,17 @@ before(async function () {
   this.timeout(U.longTimeout);
   await U.initResources();
   await U.insertUser(U.userFoo);
+  await U.insertTestTokenForUser('foo');
   await U.insertProject(U.privateProjectTest);
   await U.insertProject(U.projectTest);
-  await U.insertTestTokenForUser('foo');
   // await browser.init();
 });
 
 after(async function () {
-  await U.removeUser(U.userFoo.nickname);
   await U.removeProject(U.projectTest.shortname);
   await U.removeProject(U.privateProjectTest.shortname);
   await U.removeTestTokenForUser('foo');
+  await U.removeUser(U.userFoo.nickname);
   // await browser.close();
   await U.closeResources();
 });


### PR DESCRIPTION
<!-- Thank you for your contribution to BrainBox -->

<!-- Give a short title and description for your pull request: -->
I fixed some await problems when inserting a project to avoid concurrency problem. Hopefully this will fix the bug of some MRI annotations disappearing when inserting a project. I wasn't able to reproduce the bug but I'm still confident that this pr will fix it...

---
<!-- Run the tests. Replace each `[ ]` by `[X]` when the step is complete.-->
- [ ] These changes fix #__ (github issue number if applicable).
- [x] ```npm run mocha-test``` ran with full success.
- [] ```npm run mocha-test``` ran resulted in  failure in _____

<!-- Replace `__` with appropriate information: -->
- [ ] I implemented tests for the changes I made OR
- [x] These changes do not require tests because the bug is too difficult to reproduce in a test environment
<!-- Make sure that "Allow edits from maintainers" checkbox is checked.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification. -->


- [ ] All BrainBox tools behave as expected:
    * **KEYS**
        * right and left arrow keys
            - [ ] jump to next or previous slice within one brain, respectively
            - [ ] update the slider accordingly
            - [ ] update the slice number accordingly (upper left corner of the viewer window)
        * down and up arrow keys
            - [ ] jump to the next or previous brain within one project, respectively
            - [ ] update the selected subject in the annotation table
    * **TOOL BUTTONS**
        * minus
            - [ ] jumps to the previous slice within one brain
            - [ ] updates the slider accordingly
            - [ ] updates the slice number accordingly (upper left corner of the viewer window)
        * plus
            - [ ] jumps to the next slice within one brain
            - [ ] updates the slider accordingly
            - [ ] updates the slice number accordingly (upper left corner of the viewer window)
        * slider
            - [ ] updates slice view and slice number on the fly
        * sag / cor / axi buttons
            - [ ] switch view between the three orthogonal planes
        * show tool
            - [ ] when you click and drag in your browser window, this tool displays a cirlce at the position of your mouse click & drag as well as the user name in all browser windows connected to the same brain
        * the numbers at the bottom of the tool panel
            - [ ] change pencil size and eraser size accordingly
        * pencil tool
            - [ ] draws a line in the colour displayed in the color field
            - [ ] in combination with bucket tool filles a complete area with the chosen colour (be sure to have closed the contour line ;) Otherwise, the undo button will be your friend ;)
            - [ ] updates length and volume information (of what has been segmented) in the upper left corner of the viewer
        * erase tool
            - [ ] erases upon click drag from the annotation
            - [ ] in combination with the bucket tool erases the complete area of the color where you click
        * fill bucket tool
            * in combination with pencil tool
                - [ ] fills a complete area with the colour displayed in the colour field
            * in combination with erase tool
                - [ ] erases the complete area that is filled by the colour of where you click
        * colour field
            - [ ] displays the currently chosen colour to draw and fill
            - [ ] on click opens the set of colours available within the chosen label set where a new colour can be selected upon click
        * ruler tool
            - [ ] measures the distance between start and end of your defined path
                - [ ] points of mouse click appear and stay visible until you hit return key (this functionality is currently broken!) (you can click as many points as you wish to define the path you are interested in)
                - [ ] on return key, BrainBox will print the distance into the chat field (the ruler tool seems to be currently broken!!!)
        * adjust tool
            - [ ] slide opacity of overlaid annotation from 0 to 100%
            - [ ] increase or decrease brightness of the underlying MRI data
            - [ ] increase or decrease the contrast of the underlying MRI data
        * eyedropper tool
            - [ ] updates the colour field in the tool panel
            - [ ] displays/updates the region name in the upper left corner of the viewer
        * undo tool
            - [ ] undoes the user's actions in reverse chronological order and currently has the bug that it even undoes actions in slices you are currently not seeing! and there is currently no redo...
        * save button
            - [ ] saves the annotation of the data set into the data base
            - [ ] displays a message that user needs to login in case they are not
            - [ ] display a message `Atlas saved Wed Oct 18 2017 12:49:12 GMT+0200 (CEST)`


